### PR TITLE
[bug-fix]: Persist Build Directory between Jobs in Github Actions

### DIFF
--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -28,7 +28,8 @@ jobs:
           npm run build
           npm run test:codacy
       
-      - name: Persist build directory
+      - if: ${{ github.event_name == 'push' }}
+        name: Persist build directory
         uses: actions/upload-artifact@v2
         with:
           name: build-directory

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -15,18 +15,24 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Setup Node and Install Packages
+      - name: Install Node
         uses: actions/setup-node@v1
         with:
           node-version: 12.x
 
-      - name: Run Linting and Tests
+      - name: Install Packages, Run Linting and Tests
         env:
           CODACY_PROJECT_TOKEN: ${{ secrets.CODACY_PROJECT_TOKEN }}
         run: |
           npm ci
           npm run build
           npm run test:codacy
+      
+      - name: Persist build directory
+        uses: actions/upload-artifact@v2
+        with:
+          name: build-directory
+          path: build
 
   deploy:
     if: ${{ github.event_name == 'push' && github.repository == 'BuildForSDGCohort2/whatz-hot-frontend' }}
@@ -34,6 +40,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+
+      - name: Get saved build directory
+        uses: actions/download-artifact@v2
+        with:
+          name: build-directory
 
       - name: Deploy to Netlify
         uses: nwtgck/actions-netlify@v1.1


### PR DESCRIPTION
### Before submitting your PR for review

- Run `npm run lint` to find errors in code syntax/format
- Run `npm run lint:fix` to fix all auto-fixable errors in source code and auto-format with prettier
- Ensure you fix any linting errors displayed after running any of the above commands
- Ensure you have written new tests covering this new feature
- Ensure all old tests pass and indicate breaking changes if any

### What does this PR do?

Fixes #9

Github actions fails before job to deploy to netlify because build folder from previous job is not found

### Description of Task that was completed (include screenshots where applicable)? 

- Persist build folder between jobs using artifacts

### How should this be manually tested? 

- Merge a PR to the develop branch
- The Github action should complete and the latest build on the develop branch should be deployed to netlify
